### PR TITLE
open random node_module's npm page

### DIFF
--- a/bin/code-audit.js
+++ b/bin/code-audit.js
@@ -6,6 +6,7 @@ program.version(require('../package.json').version);
 
 const findTodos = require('../lib/findTodos');
 const findLongFunctions = require('../lib/findLongFunctions');
+const learn = require('../lib/learn');
 
 program
 	.command('todos')
@@ -16,6 +17,12 @@ program
 	.command('functions')
 	.description('Finds functions that are too long')
 	.action(findLongFunctions);
+
+program
+	.command('learn')
+	.option('--no-open', 'Don\'t open the npm package page')
+	.description('Finds a random node module and opens the readme')
+	.action(learn);
 
 program
 	.command('*')

--- a/lib/learn.js
+++ b/lib/learn.js
@@ -1,0 +1,56 @@
+const chalk = require('chalk');
+const fs = require('fs');
+const shell = require('child_process');
+const { promisify } = require('util');
+const readdir = promisify(fs.readdir);
+const exec = promisify(shell.exec);
+
+module.exports = args => {
+	const cwd = process.cwd();
+
+	readdir('./node_modules').then(modules => {
+		const randomModule = getRandomModule(modules);
+		const { name: packageName } = require(`${cwd}/node_modules/${randomModule}/package.json`);
+		const packageUrl = `https://www.npmjs.com/package/${packageName}`;
+		if (args.open) {
+			exec(`open ${packageUrl}`);
+			logGreen('Did you learn something? If you did go and tell someone what you learnt!');
+		} else {
+			logGreen(
+				`${packageName} looks interesting! You should check out it's docs at ${packageUrl}`,
+				'\nFind out what it does and go tell someone else!'
+			);
+		}
+	}).catch(err => {
+		const noDirectory = err.message.includes('no such file or directory');
+		if (noDirectory) {
+			logWarning('You haven\'t got any node modules to learn about in this directory');
+		} else {
+			throw err;
+		}
+	});
+};
+
+function getRandomModule (modules) {
+	const randomModuleNumber = getRandomInt(modules.length);
+	const randomModule = modules[randomModuleNumber];
+	const isValidModule = randomModule !== '.bin' || !randomModule.startsWith('@');
+
+	if (isValidModule) {
+		return randomModule;
+	} else {
+		return getRandomModule(modules);
+	}
+}
+
+function getRandomInt (max) {
+	return Math.floor(Math.random() * Math.floor(max));
+}
+
+function logGreen (...args) {
+	console.log(chalk.green(args));
+}
+
+function logWarning (...args) {
+	console.log(chalk.yellow(args));
+}


### PR DESCRIPTION
Adds `code-audit learn` command which finds a random installed node module and opens it's npm page. Add the `no-open` flag to not open the page and instead just log it to the console.

Closes #4 